### PR TITLE
fix the bug which can not correctly show the Macro

### DIFF
--- a/themes/Visual Assist Dark-color-theme.json
+++ b/themes/Visual Assist Dark-color-theme.json
@@ -133,6 +133,14 @@
 			}
 		},
 		{
+			"name": "Macro",
+			"scope": "entity.name.function.preprocessor",
+			"settings": {
+				"fontStyle": "",
+				"foreground": "#bd63c5"
+			}
+		},
+		{
 			"name": "Class name",
 			"scope": "entity.name.type",
 			"settings": {


### PR DESCRIPTION
before:
![image](https://github.com/user-attachments/assets/e3c7bacc-3ae5-4361-bd68-158f8a8a1044)

after:
![image](https://github.com/user-attachments/assets/32ee0e41-48a7-44d7-a9e2-5d0d054bbf87)
